### PR TITLE
#322 Install -> CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run build
   lint:
     executor:
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run lint
 
 workflows:


### PR DESCRIPTION
Docs for reference. This isn't a very well known best practice, but it does exist and thought it would be a fun small change:
https://docs.npmjs.com/cli/v7/commands/npm-ci