### PR TITLE
Better channel redirect

### DIFF
--- a/src/app/handlers/command.handler.ts
+++ b/src/app/handlers/command.handler.ts
@@ -23,12 +23,12 @@ export class CommandHandler implements IHandler {
         return;
       }
 
-      if (!plugin.validate(message, command.args)) {
-        message.reply(`Invalid arguments! Try: \`${Constants.Prefix}${plugin.usage}\``);
+      if (!isDM && !plugin.hasPermission(message)) {
         return;
       }
 
-      if (!isDM && !plugin.hasPermission(message)) {
+      if (!plugin.validate(message, command.args)) {
+        message.reply(`Invalid arguments! Try: \`${Constants.Prefix}${plugin.usage}\``);
         return;
       }
 

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -1,4 +1,6 @@
 import { ChannelType, IContainer, IMessage, IPlugin, RoleType } from './types';
+import Constants from '../common/constants';
+import { Container } from 'winston';
 
 export abstract class Plugin implements IPlugin {
   public abstract container: IContainer;
@@ -28,7 +30,15 @@ export abstract class Plugin implements IPlugin {
   public hasPermission(message: IMessage): boolean {
     const channelName = this.container.messageService.getChannel(message).name;
     if (typeof this.pluginChannelName === 'string' && this.pluginChannelName !== channelName) {
-      message.reply(`Please use this command in the \`#${this.pluginChannelName}\` channel.`);
+
+      //if this fails it simply means that a channel the bot expected to exist didn't, nothing bot breaking
+      try{
+        const id = this.container.guildService.getChannel(this.pluginChannelName).id
+        message.reply(`Please use this command in the <#${id}> channel.`);
+      }catch(err){
+        this.container.loggerService.warn(err)
+        message.reply(`Please use this command in the \`#${this.pluginChannelName}\` channel.`);
+      }
       return false;
     }
 
@@ -47,7 +57,29 @@ export abstract class Plugin implements IPlugin {
 
     const response = this.container.channelService.hasPermission(channelName, this.permission);
     if (!response) {
-      message.reply(`Please use this command in a \`${this.permission}\` channel`);
+      const rooms = Object.values(Constants.Channels[this.permission]);
+      let addonText = '';
+
+      //if this fails it simply means that a channel the bot expected to exist didn't
+      try{
+        if (rooms.length === 0) {
+          addonText = "their are no channels oh this type declared";
+        } else if (rooms.length === 1) {
+          let id = this.container.guildService.getChannel(rooms[0]).id
+          addonText = `, <#${id}> is the only channel whith this type`
+        } else{
+          let id = [this.container.guildService.getChannel(rooms[0]).id, this.container.guildService.getChannel(rooms[1]).id]
+          if (rooms.length == 2){
+            addonText = `, <#${id[0]}> and <#${id[1]}> are the only two with this channel type`
+          } else {
+            addonText = `, <#${id[0]}> and <#${id[1]}> are two of the channels this channel type`
+          }
+        }
+      } catch(err){
+        this.container.loggerService.warn(err)
+      } finally {
+        message.reply(`Please use this command in a \`${this.permission}\` channel${addonText}.`);
+      }
     }
     return response;
   }

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -29,14 +29,8 @@ export abstract class Plugin implements IPlugin {
   public hasPermission(message: IMessage): boolean {
     const channelName = this.container.messageService.getChannel(message).name;
     if (typeof this.pluginChannelName === 'string' && this.pluginChannelName !== channelName) {
-      let channel = '';
-      try {
-        channel = `<#${this.container.guildService.getChannel(this.pluginChannelName).id}>`;
-      } catch (err) {
-        this._errorGen([this.pluginChannelName], err);
-        channel = `\`#${this.pluginChannelName}\``;
-      }
-      message.reply(`Please use this command in the ${channel} channel.`);
+      const id = this.container.guildService.getChannel(this.pluginChannelName).id;
+      message.reply(`Please use this command in the ${id} channel.`);
       return false;
     }
 
@@ -55,18 +49,18 @@ export abstract class Plugin implements IPlugin {
 
     const response = this.container.channelService.hasPermission(channelName, this.permission);
     if (!response) {
-      const rooms = Object.values(Constants.Channels[this.permission]);
-      const totalChannels = rooms.length;
-      rooms.splice(3);
+      const channels = Object.values(Constants.Channels[this.permission]);
+      const totalChannels = channels.length;
+      channels.splice(3);
 
       let addonText = '';
 
       try {
         // not sure if this will cause issues as I do pop id, please let me know
-        const id = rooms
-          .filter((room) => {
+        const id = channels
+          .filter((channel) => {
             return this.container.guildService
-              .getChannel(room)
+              .getChannel(channel)
               .permissionsFor(message.member || '')
               ?.has('VIEW_CHANNEL');
           })
@@ -74,17 +68,23 @@ export abstract class Plugin implements IPlugin {
 
         if (this.permission.toString() === 'Private') {
           addonText = ` This is primarily the class channels, and any channels we haven't defined.`;
-        } else if (id.length === 0) {
+        }
+
+        if (id.length === 0) {
           addonText = ' There are no permanent channels of this type.';
-        } else if (id.length === 1) {
+        }
+
+        if (id.length === 1) {
           addonText = ` <#${id[0]}> is the only channel whith this type.`;
-        } else {
+        }
+
+        if (id.length > 1) {
           addonText =
             `\nHere are ${id.length} of the ${totalChannels} supported channel(s): \n` +
             `${id.map((chan) => `<#${chan}>`).join(',\n')}.`;
         }
       } catch (err) {
-        this._errorGen(rooms, err);
+        this._errorGen(channels, err);
       } finally {
         message.reply(`Please use this command in a \`${this.permission}\` channel.${addonText}`);
       }

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -18,6 +18,8 @@ export abstract class Plugin implements IPlugin {
 
   public pluginChannelName?: string;
 
+  private numChannelsShown: number = 6;
+
   // Typical defaults for existing commands.
   public usableInDM = false;
   public usableInGuild = true;
@@ -60,7 +62,7 @@ export abstract class Plugin implements IPlugin {
 
       const channels = Object.values(Constants.Channels[this.permission]);
       const totalChannels = channels.length;
-      channels.splice(10);
+      channels.splice(this.numChannelsShown);
 
       try {
         const id = channels

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -30,7 +30,7 @@ export abstract class Plugin implements IPlugin {
     const channelName = this.container.messageService.getChannel(message).name;
     if (typeof this.pluginChannelName === 'string' && this.pluginChannelName !== channelName) {
       const id = this.container.guildService.getChannel(this.pluginChannelName).id;
-      message.reply(`Please use this command in the ${id} channel.`);
+      message.reply(`Please use this command in the <#${id}> channel.`);
       return false;
     }
 
@@ -49,6 +49,15 @@ export abstract class Plugin implements IPlugin {
 
     const response = this.container.channelService.hasPermission(channelName, this.permission);
     if (!response) {
+      const baseReply = `Please use this command in a \`${this.permission}\` channel.`;
+
+      if (this.permission.toString() === 'Private') {
+        message.reply(
+          `${baseReply} This is primarily the class channels, and any channels we haven't defined.`
+        );
+        return response;
+      }
+
       const channels = Object.values(Constants.Channels[this.permission]);
       const totalChannels = channels.length;
       channels.splice(3);
@@ -65,27 +74,23 @@ export abstract class Plugin implements IPlugin {
           })
           .map((room) => this.container.guildService.getChannel(room).id);
 
-        if (this.permission.toString() === 'Private') {
-          addonText = ` This is primarily the class channels, and any channels we haven't defined.`;
-        }
-
         if (id.length === 0) {
-          addonText = ' There are no permanent channels of this type.';
+          message.reply(`${baseReply} There are no permanent channels of this type.`);
+          return response;
         }
 
         if (id.length === 1) {
-          addonText = ` <#${id[0]}> is the only channel with this type.`;
+          message.reply(`${baseReply} <#${id[0]}> is the only channel with this type.`);
+          return response;
         }
 
-        if (id.length > 1) {
-          addonText =
+        message.reply(
+          baseReply +
             `\nHere are ${id.length} of the ${totalChannels} supported channel(s): \n` +
-            `${id.map((chan) => `<#${chan}>`).join(',\n')}.`;
-        }
+            `${id.map((chan) => `<#${chan}>`).join(',\n')}.`
+        );
       } catch (err) {
         this._errorGen(channels, err);
-      } finally {
-        message.reply(`Please use this command in a \`${this.permission}\` channel.${addonText}`);
       }
     }
     return response;

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -1,6 +1,7 @@
 import { ChannelType, IContainer, IMessage, IPlugin, RoleType } from './types';
 import Constants from '../common/constants';
 import { Container } from 'winston';
+import { convertToObject } from 'typescript';
 
 export abstract class Plugin implements IPlugin {
   public abstract container: IContainer;
@@ -34,7 +35,7 @@ export abstract class Plugin implements IPlugin {
       //if this fails it simply means that a channel the bot expected to exist didn't, nothing bot breaking
       try{
         const id = this.container.guildService.getChannel(this.pluginChannelName).id
-        message.reply(`Please use this command in the <#${id}> channel.`);
+        message.reply(`Please use this command in <#${id}>.`);
       }catch(err){
         this.container.loggerService.warn(err)
         message.reply(`Please use this command in the \`#${this.pluginChannelName}\` channel.`);
@@ -62,8 +63,8 @@ export abstract class Plugin implements IPlugin {
 
       //if this fails it simply means that a channel the bot expected to exist didn't
       try{
-        if (rooms.length === 0) {
-          addonText = "their are no channels oh this type declared";
+        if (rooms.length === 0 && this.permission.toString() != "Private") {
+          addonText = "their are no permanant channels oh this type declared.";
         } else if (rooms.length === 1) {
           let id = this.container.guildService.getChannel(rooms[0]).id
           addonText = `, <#${id}> is the only channel whith this type`

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -1,6 +1,5 @@
 import { ChannelType, IContainer, IMessage, IPlugin, RoleType } from './types';
 import Constants from '../common/constants';
-import { idText } from 'typescript';
 
 export abstract class Plugin implements IPlugin {
   public abstract container: IContainer;
@@ -61,7 +60,8 @@ export abstract class Plugin implements IPlugin {
       const rooms = Object.values(Constants.Channels[this.permission]);
       let addonText = '';
 
-      let id = rooms
+      // not sure if this will cause issues as I do pop id, please let me know
+      const id = rooms
         .filter((room) => {
           return this.container.guildService
             .getChannel(room)

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -31,13 +31,12 @@ export abstract class Plugin implements IPlugin {
   public hasPermission(message: IMessage): boolean {
     const channelName = this.container.messageService.getChannel(message).name;
     if (typeof this.pluginChannelName === 'string' && this.pluginChannelName !== channelName) {
-
       //if this fails it simply means that a channel the bot expected to exist didn't, nothing bot breaking
-      try{
-        const id = this.container.guildService.getChannel(this.pluginChannelName).id
+      try {
+        const id = this.container.guildService.getChannel(this.pluginChannelName).id;
         message.reply(`Please use this command in <#${id}>.`);
-      }catch(err){
-        this.container.loggerService.warn(err)
+      } catch (err) {
+        this.container.loggerService.warn(err);
         message.reply(`Please use this command in the \`#${this.pluginChannelName}\` channel.`);
       }
       return false;
@@ -62,22 +61,25 @@ export abstract class Plugin implements IPlugin {
       let addonText = '';
 
       //if this fails it simply means that a channel the bot expected to exist didn't
-      try{
-        if (rooms.length === 0 && this.permission.toString() != "Private") {
-          addonText = "their are no permanant channels oh this type declared.";
+      try {
+        if (rooms.length === 0 && this.permission.toString() != 'Private') {
+          addonText = 'their are no permanant channels oh this type declared.';
         } else if (rooms.length === 1) {
-          let id = this.container.guildService.getChannel(rooms[0]).id
-          addonText = `, <#${id}> is the only channel whith this type`
-        } else{
-          let id = [this.container.guildService.getChannel(rooms[0]).id, this.container.guildService.getChannel(rooms[1]).id]
-          if (rooms.length == 2){
-            addonText = `, <#${id[0]}> and <#${id[1]}> are the only two with this channel type`
+          let id = this.container.guildService.getChannel(rooms[0]).id;
+          addonText = `, <#${id}> is the only channel whith this type`;
+        } else {
+          let id = [
+            this.container.guildService.getChannel(rooms[0]).id,
+            this.container.guildService.getChannel(rooms[1]).id,
+          ];
+          if (rooms.length == 2) {
+            addonText = `, <#${id[0]}> and <#${id[1]}> are the only two with this channel type`;
           } else {
-            addonText = `, <#${id[0]}> and <#${id[1]}> are two of the channels this channel type`
+            addonText = `, <#${id[0]}> and <#${id[1]}> are two of the channels this channel type`;
           }
         }
-      } catch(err){
-        this.container.loggerService.warn(err)
+      } catch (err) {
+        this.container.loggerService.warn(err);
       } finally {
         message.reply(`Please use this command in a \`${this.permission}\` channel${addonText}.`);
       }

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -1,7 +1,5 @@
 import { ChannelType, IContainer, IMessage, IPlugin, RoleType } from './types';
 import Constants from '../common/constants';
-import { Container } from 'winston';
-import { convertToObject } from 'typescript';
 
 export abstract class Plugin implements IPlugin {
   public abstract container: IContainer;
@@ -65,10 +63,10 @@ export abstract class Plugin implements IPlugin {
         if (rooms.length === 0 && this.permission.toString() != 'Private') {
           addonText = 'their are no permanant channels oh this type declared.';
         } else if (rooms.length === 1) {
-          let id = this.container.guildService.getChannel(rooms[0]).id;
+          const id = this.container.guildService.getChannel(rooms[0]).id;
           addonText = `, <#${id}> is the only channel whith this type`;
         } else {
-          let id = [
+          const id = [
             this.container.guildService.getChannel(rooms[0]).id,
             this.container.guildService.getChannel(rooms[1]).id,
           ];

--- a/src/common/plugin.ts
+++ b/src/common/plugin.ts
@@ -60,9 +60,7 @@ export abstract class Plugin implements IPlugin {
 
       const channels = Object.values(Constants.Channels[this.permission]);
       const totalChannels = channels.length;
-      channels.splice(3);
-
-      let addonText = '';
+      channels.splice(10);
 
       try {
         const id = channels

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -144,6 +144,23 @@ export interface IPluginLookup {
   [pluginName: string]: IPlugin;
 }
 
+export class CChannelInfo {
+  id: string;
+  name: string;
+
+  getID(): string {
+    return this.id;
+  }
+  getName(): string {
+    return this.name;
+  }
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
 export enum RoleType {
   'Suspended' = -10,
   'RegularUser' = 0,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -144,23 +144,6 @@ export interface IPluginLookup {
   [pluginName: string]: IPlugin;
 }
 
-export class CChannelInfo {
-  id: string;
-  name: string;
-
-  getID(): string {
-    return this.id;
-  }
-  getName(): string {
-    return this.name;
-  }
-
-  constructor(id: string, name: string) {
-    this.id = id;
-    this.name = name;
-  }
-}
-
 export enum RoleType {
   'Suspended' = -10,
   'RegularUser' = 0,


### PR DESCRIPTION
Gives channel redirect links rather than just some text when a user uses a command that is invalid for that room.  Also give examples in the cases of Permission types commands. With the exception of private channels since they are special in the case that we have none defined in constants, and that all channels default to that if undeclared.