### PR TITLE
Allow Admins to store all class pins at end of semester

### DIFF
--- a/src/app/plugins/storepins.plugin.ts
+++ b/src/app/plugins/storepins.plugin.ts
@@ -1,0 +1,93 @@
+import { GuildChannel, Snowflake, TextChannel } from 'discord.js';
+import { Collection } from 'mongodb';
+import { Plugin } from '../../common/plugin';
+import { IContainer, IMessage, ChannelType, Maybe, ClassType } from '../../common/types';
+
+export class StorePinsPlugin extends Plugin {
+  public name: string = 'Pin Plugin';
+  public description: string = 'pins messages to the database';
+  public usage: string = 'storepins';
+  public pluginAlias = [];
+  public permission: ChannelType = ChannelType.Admin;
+  public commandPattern: RegExp = /(confirm)?/;
+
+  private _state: boolean = false;
+
+  constructor(public container: IContainer) {
+    super();
+  }
+
+  public async execute(message: IMessage, args: string[]) {
+    const classChannels = Array.from(
+      this.container.classService.getClasses(ClassType.ALL).values()
+    );
+
+    if (!this._state) {
+      message.reply(
+        `Are you sure you want to store *all* the pins in all \`${classChannels.length}\` class channels?\n` +
+          'Reply with `!storepins confirm` if you are sure'
+      );
+      this._state = true;
+      return;
+    }
+
+    const [subCommand] = args;
+    if (subCommand.toLowerCase() !== 'confirm') {
+      message.reply('Ok, canceling.');
+      this._state = false;
+      return;
+    }
+
+    message.channel.send(
+      `Storing pins in \`${classChannels.length}\` channels. I will let you know when I am done`
+    );
+
+    const collections = await this.container.storageService.getCollections();
+    const pinCollection: Maybe<Collection<ClassPin>> = collections.pins;
+    if (!pinCollection) {
+      message.channel.send('Error connecting to the DB');
+      return;
+    }
+
+    const promises = classChannels.map((chan: GuildChannel) =>
+      this._storePinsInChannel(pinCollection, chan as TextChannel)
+    );
+    // .filter(Boolean); // Filter out those with no pins
+
+    const numPinsStored: number = (await Promise.all(promises)).reduce((acc: number, val) => {
+      if (val) {
+        return acc + val.insertedCount;
+      }
+      return acc;
+    }, 0);
+
+    message.channel.send(
+      `Stored \`${numPinsStored}\` pins in \`${classChannels.length}\` channels`
+    );
+    this._state = false;
+  }
+
+  private async _storePinsInChannel(pinCollection: Collection<ClassPin>, channel: TextChannel) {
+    const parsedPins: ClassPin[] = (await channel.messages.fetchPinned()).array().map((pin) => {
+      return {
+        messageContent: pin.content,
+        className: channel.name,
+        date: new Date(),
+        guildID: channel.guild.id,
+      };
+    });
+
+    if (parsedPins.length === 0) {
+      return null;
+    }
+
+    return pinCollection.insertMany(parsedPins);
+  }
+}
+
+export interface ClassPin {
+  messageContent: string;
+  className: string;
+  date: Date;
+  guildID: Snowflake;
+}

--- a/src/app/plugins/storepins.plugin.ts
+++ b/src/app/plugins/storepins.plugin.ts
@@ -43,7 +43,7 @@ export class StorePinsPlugin extends Plugin {
     );
 
     const collections = await this.container.storageService.getCollections();
-    const pinCollection: Maybe<Collection<ClassPin>> = collections.pins;
+    const pinCollection: Maybe<Collection<IClassPin>> = collections.pins;
     if (!pinCollection) {
       message.channel.send('Error connecting to the DB');
       return;
@@ -63,7 +63,7 @@ export class StorePinsPlugin extends Plugin {
     this._state = false;
   }
 
-  private async _getPinsInChannel(channel: TextChannel): Promise<ClassPin[]> {
+  private async _getPinsInChannel(channel: TextChannel): Promise<IClassPin[]> {
     return (await channel.messages.fetchPinned()).array().map((pin) => {
       return {
         messageContent: pin.content,
@@ -75,7 +75,7 @@ export class StorePinsPlugin extends Plugin {
   }
 }
 
-export interface ClassPin {
+export interface IClassPin {
   messageContent: string;
   className: string;
   date: Date;

--- a/src/app/plugins/storepins.plugin.ts
+++ b/src/app/plugins/storepins.plugin.ts
@@ -49,10 +49,9 @@ export class StorePinsPlugin extends Plugin {
       return;
     }
 
-    const promises = classChannels.map((chan: GuildChannel) =>
-      this._storePinsInChannel(pinCollection, chan as TextChannel)
-    );
-    // .filter(Boolean); // Filter out those with no pins
+    const promises = classChannels
+      .map((chan: GuildChannel) => this._storePinsInChannel(pinCollection, chan as TextChannel))
+      .filter(Boolean); // Filter out those with no pins
 
     const numPinsStored: number = (await Promise.all(promises)).reduce((acc: number, val) => {
       if (val) {

--- a/src/bootstrap/plugin.loader.ts
+++ b/src/bootstrap/plugin.loader.ts
@@ -42,6 +42,7 @@ import { LionPresence } from '../app/plugins/lionpresence.plugin';
 import { CommandSearchPlugin } from '../app/plugins/commandsearch.plugin';
 import { CoinToss } from '../app/plugins/cointoss.plugin';
 import { LeaderboardPlugin } from '../app/plugins/leaderboard.plugin';
+import { StorePinsPlugin } from '../app/plugins/storepins.plugin';
 
 const PluginStore: { [pluginName: string]: any } = {
   dog: DogPlugin,
@@ -87,6 +88,7 @@ const PluginStore: { [pluginName: string]: any } = {
   commandsearch: CommandSearchPlugin,
   cointoss: CoinToss,
   leaderboard: LeaderboardPlugin,
+  storepins: StorePinsPlugin,
 };
 
 export class PluginLoader {

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -5,6 +5,7 @@ import { LoggerService } from './logger.service';
 import { ITAEntry } from '../app/plugins/ta.plugin';
 import { IGameLeaderBoardEntry } from './gameleaderboard.service';
 import { IServerInfo } from '../common/types';
+import { ClassPin } from '../app/plugins/storepins.plugin';
 
 export class StorageService {
   private _db?: Db;
@@ -18,6 +19,7 @@ export class StorageService {
     tttLeaderboard?: Collection<IGameLeaderBoardEntry>;
     connectFourLeaderboard?: Collection<IGameLeaderBoardEntry>;
     serverInfo?: Collection<IServerInfo>;
+    pins?: Collection<ClassPin>;
   } = {};
 
   public constructor(private _loggerService: LoggerService) {
@@ -48,6 +50,7 @@ export class StorageService {
       this._collections.tttLeaderboard = this._db.collection('tttLeaderboard');
       this._collections.connectFourLeaderboard = this._db.collection('connectFourLeaderboard');
       this._collections.serverInfo = this._db.collection('serverInfo');
+      this._collections.pins = this._db.collection('pins');
 
       console.info(`Successfully connected to ${this._db.databaseName}`);
     } catch (e) {

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -5,7 +5,7 @@ import { LoggerService } from './logger.service';
 import { ITAEntry } from '../app/plugins/ta.plugin';
 import { IGameLeaderBoardEntry } from './gameleaderboard.service';
 import { IServerInfo } from '../common/types';
-import { ClassPin } from '../app/plugins/storepins.plugin';
+import { IClassPin } from '../app/plugins/storepins.plugin';
 
 export class StorageService {
   private _db?: Db;
@@ -19,7 +19,7 @@ export class StorageService {
     tttLeaderboard?: Collection<IGameLeaderBoardEntry>;
     connectFourLeaderboard?: Collection<IGameLeaderBoardEntry>;
     serverInfo?: Collection<IServerInfo>;
-    pins?: Collection<ClassPin>;
+    pins?: Collection<IClassPin>;
   } = {};
 
   public constructor(private _loggerService: LoggerService) {


### PR DESCRIPTION
Admins can store all class pins with one command into the DB, that way next semester can see what was useful to the last class

Will eventually need another plugin to view a classes old pins
And probably a way to prune not very useful pins