### PR TITLE
Fixed Fuzzy search to use hasPermission

### DIFF
--- a/src/app/handlers/command.handler.ts
+++ b/src/app/handlers/command.handler.ts
@@ -1,7 +1,7 @@
 import * as types from '../../common/types';
 import Constants from '../../common/constants';
 import levenshtein from 'js-levenshtein';
-import { MessageEmbed, MessageReaction, TextChannel, User } from 'discord.js';
+import { MessageEmbed, MessageReaction, User } from 'discord.js';
 import ms from 'ms';
 
 export class CommandHandler implements types.IHandler {
@@ -40,23 +40,9 @@ export class CommandHandler implements types.IHandler {
     const { plugins, aliases } = this.container.pluginService;
     const allNames = Array.from(Object.keys(this.container.pluginService.aliases));
 
-    const currentChannelName = (message.channel as TextChannel).name.toLowerCase();
     const validCommandsInChannel = allNames.filter((name) => {
       const plugin = plugins[aliases[name]];
-
-      // Check channel type
-      const permLevel = plugin.permission;
-      if (permLevel !== this.container.channelService.getChannelType(currentChannelName)) {
-        return false;
-      }
-
-      // If there is a specific channel, make sure it's this one
-      const pluginChannel = plugin.pluginChannelName;
-      if (!pluginChannel) {
-        return true;
-      }
-
-      return pluginChannel.toLowerCase() === currentChannelName;
+      return plugin.hasPermission(message);
     });
 
     const [mostLikelyCommand] = validCommandsInChannel.sort(

--- a/src/app/handlers/command.handler.ts
+++ b/src/app/handlers/command.handler.ts
@@ -42,7 +42,7 @@ export class CommandHandler implements types.IHandler {
 
     const validCommandsInChannel = allNames.filter((name) => {
       const plugin = plugins[aliases[name]];
-      return plugin.hasPermission(message);
+      return plugin.hasPermission(message) === true;
     });
 
     const [mostLikelyCommand] = validCommandsInChannel.sort(


### PR DESCRIPTION
```
Jul 01 21:05:09 SandboxHost-637606729806204385 default error Cannot read property 'toLowerCase' of undefined 
Jul 01 21:05:09 SandboxHost-637606729806204385 default error     TypeError: Cannot read property 'toLowerCase' of undefined 
Jul 01 21:05:09 SandboxHost-637606729806204385 default error         at CommandHandler._tryFuzzySearch (/usr/src/lion/dist/app/handlers/command.handler.js:41:57) 
Jul 01 21:05:09 SandboxHost-637606729806204385 default error         at CommandHandler.execute
...
```
Forgot about the Plugin#hasPermission when I coded this, it would assume that the channel had a channel name.
Fixed the error, and it now using the up-to-date `hasPermission` function

Will not work until #519, because of side effect inside of `hasPermission`