### PR TITLE
job improvements

### DIFF
--- a/src/common/job.ts
+++ b/src/common/job.ts
@@ -2,8 +2,7 @@ import ms from 'ms';
 import { IJob, IContainer } from './types';
 
 export abstract class Job implements IJob {
-  public name: string = '';
+  public abstract get name(): string;
   public interval: number = ms('1m');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public execute(container?: IContainer) {}
+  public abstract execute(container?: IContainer): void;
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -166,12 +166,20 @@ export enum RoleType {
   'Admin' = 40,
 }
 
-export interface IPluginEvent {
+export interface IEvent {
   status: string;
-  pluginName: string;
-  args: string[];
   error?: string;
+}
+
+export interface IPluginEvent extends IEvent {
+  args: string[];
   user: string;
+  pluginName: string;
+}
+
+export interface IJobEvent extends IEvent {
+  jobType: string,
+  jobName: string,
 }
 
 export interface IEmojiTable {

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -1,6 +1,6 @@
 import { ExampleJob } from '../app/jobs/example.job';
 import { Job } from '../common/job';
-import { IContainer } from '../common/types';
+import { IContainer, IJobEvent } from '../common/types';
 import { UnBanJob } from '../app/jobs/unban.job';
 import { PoliticsCoCReminder } from '../app/jobs/politicscoc.job';
 import { InactiveVoiceJob } from '../app/jobs/inactivevoice.job';
@@ -23,11 +23,22 @@ export class JobService {
       throw new Error(`Job ${job.name} already exists as a running job.`);
     }
     this._runningJobs[job.name] = setInterval(() => {
+
+      const jobEvent: IJobEvent = {
+        status: 'starting',
+        jobName: job.name,
+        jobType: job.constructor.name,
+      };
+
       try {
-        container.loggerService.info(`${job.constructor.name}-(${job.name}) started.`);
+        container.loggerService.info(JSON.stringify(jobEvent));
         job.execute(container);
+        jobEvent.status = 'fulfillJob';
+        container.loggerService.info(JSON.stringify(jobEvent));
       } catch(error) {
-        container.loggerService.error(error);
+        jobEvent.status = 'error';
+        jobEvent.error = error;
+        container.loggerService.error(JSON.stringify(jobEvent));
       }
     }, job.interval);
   }

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -23,7 +23,11 @@ export class JobService {
       throw new Error(`Job ${job.name} already exists as a running job.`);
     }
     this._runningJobs[job.name] = setInterval(() => {
-      return job.execute(container);
+      try {
+        return job.execute(container);
+      } catch(error) {
+        container.loggerService.error(error);
+      }
     }, job.interval);
   }
 

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -24,7 +24,8 @@ export class JobService {
     }
     this._runningJobs[job.name] = setInterval(() => {
       try {
-        return job.execute(container);
+        container.loggerService.info(`${job.name} started.`);
+        job.execute(container);
       } catch(error) {
         container.loggerService.error(error);
       }

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -24,7 +24,7 @@ export class JobService {
     }
     this._runningJobs[job.name] = setInterval(() => {
       try {
-        container.loggerService.info(`${job.name} started.`);
+        container.loggerService.info(`${job.constructor.name}-(${job.name}) started.`);
         job.execute(container);
       } catch(error) {
         container.loggerService.error(error);


### PR DESCRIPTION
Fixes #389, 

When a job starts it's in the format

`"JOB-(JOB_NAME) started"`

In addition it makes the `name` and `execute` abstract properties in the `Job` class since all of the job subclasses implement them anyways.