### PR TITLE
Prevent nick names from including pings

### DIFF
--- a/src/app/handlers/user_update.handler.ts
+++ b/src/app/handlers/user_update.handler.ts
@@ -15,8 +15,8 @@ export class UserUpdateHandler implements IHandler {
 
     this.container.messageService.sendBotReport(
       `User ${shouldPing ? newUser.user : newUser.user.tag} changed their name from \`${
-        oldUser.displayName
-      }\` to \`${newUser.displayName}\``
+        oldUser.displayName.replace('`', '\'')
+      }\` to \`${newUser.displayName.replace('`', '\'')}\``
     );
   }
 }


### PR DESCRIPTION
Removes the  ` character from showing up in nicknames logs, and replaces it with ' 

This prevents the creation of links to channels and pings of roles/users with the id of that channel/role/user.

Example of pings:
```
<#channel_id> - this links to the channel specified by channel_id
<@user_id>    - this pings the user specified by user_id
<@&role_id>   - this pings the role specified by role_id
```

This fixes #573 