### PR TITLE
Fixed quote indentation issue on mobile

### DIFF
--- a/src/app/plugins/quote.plugin.ts
+++ b/src/app/plugins/quote.plugin.ts
@@ -56,7 +56,7 @@ export default class QuotePlugin extends Plugin {
       .setTitle(tag === 'Famous-quotes' ? 'Famous-Quotes' : tag)
       .setFooter('Pulled from api.quotable.io')
       .setTimestamp(new Date())
-      .setDescription(content + '\n\n- ' + author);
+      .setDescription(`${content}\n\n- ${author}`);
   }
 
   private _capitalizeTag(tag: string) {

--- a/src/app/plugins/quote.plugin.ts
+++ b/src/app/plugins/quote.plugin.ts
@@ -56,11 +56,7 @@ export default class QuotePlugin extends Plugin {
       .setTitle(tag === 'Famous-quotes' ? 'Famous-Quotes' : tag)
       .setFooter('Pulled from api.quotable.io')
       .setTimestamp(new Date())
-      .setDescription(
-        `${content}
-
-        - ${author}`
-      );
+      .setDescription(content + '\n\n- ' + author);
   }
 
   private _capitalizeTag(tag: string) {


### PR DESCRIPTION
There is an indent before the author name on mobile.  This should fix it.