### PR TITLE
Remove market sold feature

### DIFF
--- a/src/app/plugins/marketplace.plugin.ts
+++ b/src/app/plugins/marketplace.plugin.ts
@@ -50,7 +50,7 @@ export default class MarketPlacePlugin extends Plugin {
       this._getSellChannel(),
       300
     );
-    const itemsForSale = this._fetchListings(oldMessages);
+    const itemsForSale = await this._fetchListings(oldMessages);
 
     if (!itemsForSale.length) {
       await message.reply('Sorry, I could not find any listings');
@@ -128,12 +128,14 @@ export default class MarketPlacePlugin extends Plugin {
     this._lastListingPost = newPosting;
   }
 
-  private _fetchListings(messages: Message[]): string[] {
-    const calls = messages.filter(
-      (msg) =>
-        (msg.content.startsWith(this._LISTING_PREFIX) || // Filter out non !market adds
-          msg.content.startsWith(this._ALIAS_PREFIX)) &&
-        !this._listingIsSold(msg) // Filter out sold listings
+  private async _fetchListings(messages: Message[]): Promise<string[]> {
+    const calls = await Promise.all(
+      messages.filter(
+        async (msg) =>
+          (msg.content.startsWith(this._LISTING_PREFIX) || // Filter out non !market adds
+            msg.content.startsWith(this._ALIAS_PREFIX)) &&
+          !(await this._listingIsSold(msg)) // Filter out sold listings
+      )
     );
 
     return calls.reduce((acc: string[], msg) => {

--- a/src/app/plugins/marketplace.plugin.ts
+++ b/src/app/plugins/marketplace.plugin.ts
@@ -133,7 +133,7 @@ export default class MarketPlacePlugin extends Plugin {
       (msg) =>
         (msg.content.startsWith(this._LISTING_PREFIX) || // Filter out non !market adds
           msg.content.startsWith(this._ALIAS_PREFIX)) &&
-        !Boolean(msg.reactions.cache.find((r) => r.emoji.name === this._SOLD_EMOJI)) // Filter out sold listings
+        !this._listingIsSold(msg) // Filter out sold listings
     );
 
     return calls.reduce((acc: string[], msg) => {
@@ -144,6 +144,21 @@ export default class MarketPlacePlugin extends Plugin {
 
       return acc;
     }, []);
+  }
+
+  private async _listingIsSold(message: IMessage): Promise<boolean> {
+    // Check if sold
+    const hasTargetReaction = message.reactions.cache.find(
+      (r) => r.emoji.name === this._SOLD_EMOJI
+    );
+
+    if (!hasTargetReaction) {
+      return false;
+    }
+
+    // Check that the author is the one who reacted
+    const users = await hasTargetReaction.users.fetch();
+    return users.has(message.author.id);
   }
 
   private _resolveToListing(msg: IMessage): Maybe<string> {


### PR DESCRIPTION
Bug introduced in #312 allowed users to mark others' posts as sold.

I have decided to remove this feature, as when I tried to reintroduce it the bot takes a long time to await the reactions' users.
This feature does the exact same as removing the `!market add` from your message, since #312 made it so that sold listings are no longer visible.
The DM from the bot has been changed to reflect this.