### PR TITLE
Only show plugins in help if active

### DIFF
--- a/src/app/plugins/help.plugin.ts
+++ b/src/app/plugins/help.plugin.ts
@@ -36,7 +36,7 @@ export default class HelpPlugin extends Plugin {
   private _getEmbed(message: IMessage, type: string) {
     const plugins = Object.keys(this.container.pluginService.plugins).filter((p: string) => {
       const plugin = this.container.pluginService.get(p);
-      return plugin.hasPermission(message) === true;
+      return plugin.hasPermission(message) === true && plugin.isActive;
     });
 
     return this.container.pluginService.generateHelpEmbeds(plugins, type);


### PR DESCRIPTION
fixes #662
Removes visibility of a plugin after calling `!help` if its currently disabled