### PR TITLE
Allow ID's for CheckClasses Plugin

### DIFF
--- a/src/__tests__/checkclasses.test.ts
+++ b/src/__tests__/checkclasses.test.ts
@@ -4,7 +4,6 @@ import { getContainerMock } from '../__mocks__';
 describe('CheckClasses Arg Tests', () => {
   test('Name with no spaces', () => {
     const plugin = new CheckClassesPlugin(getContainerMock());
-
     const input = 'Tanndlin#4450';
 
     const test = plugin.commandPattern.test(input);
@@ -13,7 +12,6 @@ describe('CheckClasses Arg Tests', () => {
 
   test('Name with spaces', () => {
     const plugin = new CheckClassesPlugin(getContainerMock());
-
     const input = 'Tanndlin Test#6270';
 
     const test = plugin.commandPattern.test(input);
@@ -22,7 +20,6 @@ describe('CheckClasses Arg Tests', () => {
 
   test('ID as handle', () => {
     const plugin = new CheckClassesPlugin(getContainerMock());
-
     const input = '97478270424985600';
 
     const test = plugin.commandPattern.test(input);
@@ -31,7 +28,6 @@ describe('CheckClasses Arg Tests', () => {
 
   test('ID with suffix should be false', () => {
     const plugin = new CheckClassesPlugin(getContainerMock());
-
     const input = '97478270424985600 hello';
 
     const test = plugin.commandPattern.test(input);
@@ -40,7 +36,6 @@ describe('CheckClasses Arg Tests', () => {
 
   test('ID with prefix should be false', () => {
     const plugin = new CheckClassesPlugin(getContainerMock());
-
     const input = 'hello 97478270424985600';
 
     const test = plugin.commandPattern.test(input);

--- a/src/__tests__/checkclasses.test.ts
+++ b/src/__tests__/checkclasses.test.ts
@@ -1,0 +1,49 @@
+import CheckClassesPlugin from '../app/plugins/checkclasses.plugin';
+import { getContainerMock } from '../__mocks__';
+
+describe('CheckClasses Arg Tests', () => {
+  test('Name with no spaces', () => {
+    const plugin = new CheckClassesPlugin(getContainerMock());
+
+    const input = 'Tanndlin#4450';
+
+    const test = plugin.commandPattern.test(input);
+    expect(test).toBeTruthy();
+  });
+
+  test('Name with spaces', () => {
+    const plugin = new CheckClassesPlugin(getContainerMock());
+
+    const input = 'Tanndlin Test#6270';
+
+    const test = plugin.commandPattern.test(input);
+    expect(test).toBeTruthy();
+  });
+
+  test('ID as handle', () => {
+    const plugin = new CheckClassesPlugin(getContainerMock());
+
+    const input = '97478270424985600';
+
+    const test = plugin.commandPattern.test(input);
+    expect(test).toBeTruthy();
+  });
+
+  test('ID with suffix should be false', () => {
+    const plugin = new CheckClassesPlugin(getContainerMock());
+
+    const input = '97478270424985600 hello';
+
+    const test = plugin.commandPattern.test(input);
+    expect(test).toBeFalsy();
+  });
+
+  test('ID with prefix should be false', () => {
+    const plugin = new CheckClassesPlugin(getContainerMock());
+
+    const input = 'hello 97478270424985600';
+
+    const test = plugin.commandPattern.test(input);
+    expect(test).toBeFalsy();
+  });
+});

--- a/src/app/plugins/checkclasses.plugin.ts
+++ b/src/app/plugins/checkclasses.plugin.ts
@@ -1,6 +1,7 @@
 import { Plugin } from '../../common/plugin';
 import { IContainer, IMessage, ChannelType, ClassType } from '../../common/types';
 import Constants from '../../common/constants';
+import { Moderation } from '../../services/moderation.service';
 
 export default class CheckClassesPlugin extends Plugin {
   public commandName: string = 'checkclasses';
@@ -10,7 +11,7 @@ export default class CheckClassesPlugin extends Plugin {
   public override pluginAlias = [];
   public permission: ChannelType = ChannelType.Staff;
   public override pluginChannelName: string = Constants.Channels.Staff.ModCommands;
-  public override commandPattern: RegExp = /[^#]+#\d{4}/;
+  public override commandPattern: RegExp = /^(([^#]+#\d{4})|\d{17,18})$/;
 
   private _MAX_CHANS_SHOWN: number = 10;
 
@@ -21,10 +22,11 @@ export default class CheckClassesPlugin extends Plugin {
   public async execute(message: IMessage, args: string[]) {
     const targetUserName = args.join(' ');
 
-    const member = this.container.guildService
-      .get()
-      .members.cache.filter((m) => m.user.tag === targetUserName)
-      .first();
+    const member = await Moderation.Helpers.resolveUser(
+      this.container.guildService.get(),
+      targetUserName
+    );
+
     if (!member) {
       await message.reply('User not found.');
       return;

--- a/src/app/plugins/checkclasses.plugin.ts
+++ b/src/app/plugins/checkclasses.plugin.ts
@@ -20,11 +20,11 @@ export default class CheckClassesPlugin extends Plugin {
   }
 
   public async execute(message: IMessage, args: string[]) {
-    const targetUserName = args.join(' ');
+    const userHandle = args.join(' ');
 
     const member = await Moderation.Helpers.resolveUser(
       this.container.guildService.get(),
-      targetUserName
+      userHandle
     );
 
     if (!member) {

--- a/src/app/plugins/modreport.plugin.ts
+++ b/src/app/plugins/modreport.plugin.ts
@@ -71,7 +71,7 @@ export default class ModReportPlugin extends Plugin {
   }
 
   private async _createReport(message: IMessage, user_handle: string, description?: string) {
-    const id = await Moderation.Helpers.resolveUser(this.container.guildService.get(), user_handle);
+    const id = await Moderation.Helpers.resolveToID(this.container.guildService.get(), user_handle);
 
     if (!id) {
       return;


### PR DESCRIPTION
Does what the title says.

I made a new method in Moderation to convert a form of identification into a `GuildMember`.
Used that to parse the args for the CheckClasses Plugin

And added unit test for the regex to be safe