### PR TITLE
Exit early in blacklist handler

### DIFF
--- a/src/app/handlers/blacklist.handler.ts
+++ b/src/app/handlers/blacklist.handler.ts
@@ -66,6 +66,10 @@ export class BlacklistHandler extends Handler {
       }
     });
 
+    if (deleted) {
+      return;
+    }
+
     const isClassChannel = this.container.classService.getClasses(ClassType.ALL).has(channel.name);
     const hasBackticks = message.content.toLowerCase().match(/```/);
     const hasAttachment = message.attachments.size;

--- a/src/app/handlers/blacklist.handler.ts
+++ b/src/app/handlers/blacklist.handler.ts
@@ -44,8 +44,9 @@ export class BlacklistHandler extends Handler {
       return;
     }
 
+    let deleted = false;
     this._expressions.forEach(async ({ regex, label }) => {
-      if (message.content.toLowerCase().match(regex)) {
+      if (message.content.toLowerCase().match(regex) && !deleted) {
         message.author.send(
           `Please do not share \`${label}\` links in the \`${
             this.container.guildService.get().name
@@ -59,6 +60,9 @@ export class BlacklistHandler extends Handler {
         );
         await this.container.modService.fileReport(rep);
         await message.delete().catch(() => {});
+
+        // Trying to access the messages attributes after deletion could cause a crash
+        deleted = true;
       }
     });
 


### PR DESCRIPTION
When the message is deleted it **could??** cause a crash if we try to access its attributes later. So exit the loop early in that case.

I'm not sure of a better way to do this that is still obvious what's trying to be accomplished.
Technically using a `.every` would exit early when you `return false` but that just feels unintuitive for what I'm trying to do