### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -25,7 +25,7 @@ const buildPluginFriendlyName = (name) =>
   name
     .split(' ')
     .filter(Boolean)
-    .map((token) => `${token.substr(0, 1).toUpperCase()}${token.substr(1)}`)
+    .map((token) => `${token.slice(0, 1).toUpperCase()}${token.slice(1)}`)
     .join('')
     .concat('Plugin');
 
@@ -40,7 +40,7 @@ const buildPluginLoader = (pluginLoader, pluginName, fileName) => {
   return tokens.join('\n').replace(
     `};`,
 
-    `  ${pluginName.toLowerCase().substr(0, pluginName.length - 6)}: ${pluginName},
+    `  ${pluginName.toLowerCase().slice(0, -6)}: ${pluginName},
 };`
   );
 };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.