### PR TITLE
[FixingLion] solve a few problems, add a few logs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/src/index.ts",
+      "preLaunchTask": "tsc: build - tsconfig.json",
+      "outFiles": ["${workspaceFolder}/**/*.js"]
+    }
+  ]
+}

--- a/src/bootstrap/container.ts
+++ b/src/bootstrap/container.ts
@@ -56,7 +56,7 @@ export class Container {
       'loggerService'
     );
     this._bottle.service('userService', UserService, 'guildService');
-    this._bottle.service('controllerService', ControllerService);
+    this._bottle.service('controllerService', ControllerService, 'loggerService');
     this._bottle.service('pointService', PointService, 'guildService');
   }
 }

--- a/src/services/logger.service.ts
+++ b/src/services/logger.service.ts
@@ -21,18 +21,17 @@ export class LoggerService implements ILoggerWrapper {
       exceptionHandlers: [new Winston.transports.File({ filename: 'exceptions.log' })],
     });
 
-    if (process.env.NODE_ENV !== Mode.Production || !process.env.PAPERTRAIL_HOST) {
-      this._loggerInstance.add(
-        new Winston.transports.Console({
-          format: Winston.format.combine(Winston.format.timestamp(), Winston.format.simple()),
-        })
-      );
-    } else {
+    this._loggerInstance.add(
+      new Winston.transports.Console({
+        format: Winston.format.combine(Winston.format.timestamp(), Winston.format.simple()),
+      })
+    );
+
+    if (process.env.NODE_ENV === Mode.Production && process.env.PAPERTRAIL_HOST) {
       const papertrailTransport = new Papertrail({
         host: process.env.PAPERTRAIL_HOST,
         port: +(process.env.PAPERTRAIL_PORT ?? 0),
       });
-      papertrailTransport.on('error', console.error);
       this._loggerInstance.add(papertrailTransport);
     }
   }

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -16,22 +16,23 @@ export class StorageService {
 
     const connectionString = this._buildMongoConnectionString();
 
+    this._loggerService.debug(`Connecting to ${connectionString}`);
     try {
-      this._loggerService.debug(`Connecting to ${connectionString}`);
       this._client = await mongoose.connect(connectionString, {
         bufferMaxEntries: 0,
         useNewUrlParser: true,
         useUnifiedTopology: true,
       });
-
-      this._db = this._client.connection.db;
-
-      console.info(`Successfully connected to ${this._db.databaseName}`);
     } catch (e) {
-      this._loggerService.error(e);
-    } finally {
-      return this._db;
+      this._loggerService.error('Failed to connect to mongo.');
+      return undefined;
     }
+
+    this._db = this._client.connection.db;
+
+    this._loggerService.info(`Successfully connected to ${this._db.databaseName}`);
+
+    return this._db;
   }
 
   private _buildMongoConnectionString(): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "types": ["node", "jest"],
     "esModuleInterop": true,
     "noImplicitOverride": true,
+    "sourceMap": true
   },
   "include": ["src/**/*"]
 }
-


### PR DESCRIPTION
So the upgrade to 16.6+ probably helped us here. But we still had a few problems...

One thing I noticed: my local `dist` folder was so old and I hadn't flushed it in so long that my `node dist/index.js` would crash mysteriously. I used the VS Code interactive debugger to find that it was some reference to an old wolfram alpha library (since removed) that was crashing the code.

That got me curious. what if the cached build layers in my local docker and also on ACR are old, and they have the same problem. Alas, this was not the case. The build logs in GH Actions and my own indicate that we are doing fresh builds where we care to.

So there was another problem, that is when the bot can't connect to the DB but still tries to write to it? I noticed that it connected fine and the bot stayed online whenever I ran it from my now-repaired `node dist/index.js`. 

This code below I found quite concerning. First we were doing a console.log for the error and not a regular log. And so that would never show up in papertrail (But should in azure?). 

https://github.com/cs-discord-at-ucf/lion/blob/master/src/services/storage.service.ts#L12-L35

The only other caller of connectToDB is here

https://github.com/cs-discord-at-ucf/lion/blob/master/src/services/controller.service.ts#L8-L33

and this code is wrong. It checks `readyState` for truthiness, even though you can see here that you would only want to interact with the DB if it's `readyState` is `1`.

```
    /**
     * Connection ready state
     *
     * - 0 = disconnected
     * - 1 = connected
     * - 2 = connecting
     * - 3 = disconnecting
     */
    readyState: number;
```

Additionally, the extra call to `connectToDB` causes us to try to connect to the DB twice. If we fail to connect we run into this. We still have to investigate why we aren't able to connect from within docker. 

I have also opened https://github.com/cs-discord-at-ucf/lion/issues/699 to address potentially unsafe attempts to access the DB. I think in the switch to mongoose ( https://github.com/cs-discord-at-ucf/lion/pull/497 ) we made some assumptions about how to interact with models. I may be wrong, because I don't deeply understand how mongoose works... lot of magic going on there. 

This PR should get us to a state where the bot stays up but will maybe crash if you try to do a DB operation when we aren't DB connected.

Oh and I've also hopefully helped the no logs in azure problem? 

