### PR TITLE
Fix Classservice.addClasses

### DIFF
--- a/src/services/class.service.ts
+++ b/src/services/class.service.ts
@@ -207,7 +207,7 @@ export class ClassService {
         for (const classType of Object.keys(types.ClassType).filter(
           (k) => k !== types.ClassType.ALL
         )) {
-          if (category.name.toUpperCase().startsWith(classType)) {
+          if (category.name.toUpperCase() === `${classType}-CLASSES`) {
             const classes = this.getClasses(this.resolveClassType(classType));
             classes.set(channel.name, channel);
             this._channels.set(this.resolveClassType(classType), classes);


### PR DESCRIPTION
Fixes #721 

When adding the classes to the map, it used to match categories to classtypes by checking what it started with

That did not work because `CSGRAD` starts with `CS` causing duplicate classes