### PR TITLE
expose port 3000 in dockerfile (for railway)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build
+EXPOSE 3000
 CMD ["node", "./dist/index.js"]


### PR DESCRIPTION
didnt need this on azure since we configured it in the build workflow. since railway uses the dockerfile as the one source of truth, we need to expose 3000 for the /health endpoint 