### PR TITLE
fix race condition for uploading slash commands

### DIFF
--- a/src/app/bot.ts
+++ b/src/app/bot.ts
@@ -164,9 +164,8 @@ export class Bot {
       // Only start registration once the initial cache is populated.
       this.container.clientService.on('ready', async () => {
         await this._loadAndRun();
+        this.container.loggerService.info('Bot loaded.');
       });
-
-      this.container.loggerService.info('Bot loaded.');
       while (true) {
         const waiting = new Promise((resolve) => setTimeout(resolve, 1_000_000_000));
         await waiting;

--- a/src/app/bot.ts
+++ b/src/app/bot.ts
@@ -161,7 +161,10 @@ export class Bot {
         this.container.loggerService.error(`Could not connect to db: ${e}`);
       }
 
-      await this._loadAndRun();
+      // Only start registration once the initial cache is populated.
+      this.container.clientService.on('ready', async () => {
+        await this._loadAndRun();
+      });
 
       this.container.loggerService.info('Bot loaded.');
       while (true) {


### PR DESCRIPTION
The guild cache isn't guaranteed to be populated until the `ready` event in discord.js is invoked. This PR simply defers bot setup until the ready event to ensure the cache is also populated.