### PR TITLE
Optional initialize method for slash commands

### DIFF
--- a/src/app/bot.ts
+++ b/src/app/bot.ts
@@ -89,6 +89,7 @@ export class Bot {
         // property, but this should be fine for now
         if (result.success) {
           slashCommands.set(plugin.commandName, result.data as ISlashCommand);
+          plugin.initialize?.(this.container);
         } else {
           this.container.loggerService.warn(
             `${file} does not \`export default\` a plugin with type ISlashCommand!`

--- a/src/common/slash.ts
+++ b/src/common/slash.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionData, CommandInteraction } from 'discord.js';
-import { IContainer } from './types';
 import { z } from 'zod';
+import { IContainer } from './types';
 
 export const slashCommands: Map<string, ISlashCommand> = new Map();
 
@@ -13,6 +13,12 @@ export const SlashCommand = z.object({
     .function()
     .args(z.any())
     .returns(z.union([z.void(), z.promise(z.void())])),
+  initialize: z.optional(
+    z
+      .function()
+      .args(z.any())
+      .returns(z.union([z.void(), z.promise(z.void())]))
+  ),
 });
 
 export interface ISlashCommand {
@@ -27,4 +33,5 @@ export interface ISlashCommand {
     interaction: CommandInteraction;
     container: IContainer;
   }): void | Promise<void>;
+  initialize?(container: IContainer): void | Promise<void>;
 }


### PR DESCRIPTION
Optional method on startup to initialize a slash command, since some of our plugins require fetching data.

Takes place of the constructor in the legacy plugins