### PR TITLE
tell users about slash command if prefix command is used

### DIFF
--- a/src/app/handlers/command.handler.ts
+++ b/src/app/handlers/command.handler.ts
@@ -44,14 +44,12 @@ export class CommandHandler extends Handler {
     if (slashCommand) {
       const cachedCommand = this.container.guildService
         .get()
-        .commands.cache.find((c) => c.name === command.name);
+        .commands.cache.find((c) => c.name === command.name)!;
 
-      if (cachedCommand) {
-        await message.reply(
-          `The command \`!${command.name}\` has been migrated to a slash command, please use </${cachedCommand.name}:${cachedCommand.id}> instead.`
-        );
-        return;
-      }
+      await message.reply(
+        `The command \`!${command.name}\` has been migrated to a slash command, please use </${cachedCommand.name}:${cachedCommand.id}> instead.`
+      );
+      return;
     }
 
     await this._tryFuzzySearch(message, command, isDM);

--- a/src/app/handlers/command.handler.ts
+++ b/src/app/handlers/command.handler.ts
@@ -4,6 +4,7 @@ import levenshtein from 'js-levenshtein';
 import { MessageEmbed, MessageReaction, User } from 'discord.js';
 import ms from 'ms';
 import { Handler } from '../../common/handler';
+import { commands } from '../../common/slash';
 
 export class CommandHandler extends Handler {
   public name: string = 'Command';
@@ -35,6 +36,22 @@ export class CommandHandler extends Handler {
     if (plugin) {
       await this._attemptRunPlugin(message, plugin, command, isDM);
       return;
+    }
+
+    // Check if a slash command of the same name exists, if so redirect to it
+    const slashCommand = commands.get(command.name);
+
+    if (slashCommand) {
+      const cachedCommand = this.container.guildService
+        .get()
+        .commands.cache.find((c) => c.name === command.name);
+
+      if (cachedCommand) {
+        await message.reply(
+          `The command \`!${command.name}\` has been migrated to a slash command, please use </${cachedCommand.name}:${cachedCommand.id}> instead.`
+        );
+        return;
+      }
     }
 
     await this._tryFuzzySearch(message, command, isDM);


### PR DESCRIPTION
This sends a message to the user if a prefix command (with the same name as a slash command) is used telling them to use the slash command version instead. Demo:

https://github.com/cs-discord-at-ucf/lion/assets/77477100/c81df0ce-c987-410e-9fe4-27a5958a4829

