### PR TITLE
Optimize gamble queries

### DIFF
--- a/src/app/commands/pointLeaderboard.ts
+++ b/src/app/commands/pointLeaderboard.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed, Formatters } from 'discord.js';
+import { Formatters, MessageEmbed } from 'discord.js';
 import { Command } from '../../common/slash';
 import { IUserPoints } from '../../common/types';
 
@@ -9,9 +9,9 @@ export default {
   async execute({ interaction, container }) {
     await interaction.deferReply();
 
-    const [userDoc, userRank, topPoints] = await Promise.all([
-      container.pointService.getUserPointDoc(interaction.user.id),
-      container.pointService.getUserRank(interaction.user.id),
+    const userDoc = await container.pointService.getUserPointDoc(interaction.user.id);
+    const [userRank, topPoints] = await Promise.all([
+      container.pointService.getUserRank(userDoc.numPoints),
       container.pointService.getTopPoints(15),
     ]);
 


### PR DESCRIPTION
Uses built in mongoqb queries to limit the amount of fetch documents when using point related plugins.

The gamble and tacoleaderboard plugins used to take 10 seconds when waiting for all documents to then sort on the client side.
The mongodb queries are much faster and only take a few ms