### PR TITLE
Fixed casing missmatch

### DIFF
--- a/src/app/commands/cat.command.ts
+++ b/src/app/commands/cat.command.ts
@@ -46,8 +46,8 @@ const command: Command = {
     let searchCom = '';
 
     const breedIn = interaction.options.getString('breed')?.toLowerCase() ?? 'random';
-    // checks if their was a bread was a breed, then if that breed is recognized
-    const breedEntry = ALL_BREEDS.find((breed) => breed.name === breedIn);
+    // checks if their was a breed was a breed, then if that breed is recognized
+    const breedEntry = ALL_BREEDS.find((breed) => breed.name.toLowerCase() === breedIn);
 
     if (breedEntry !== undefined) {
       searchCom = '&breed_ids=' + breedEntry.id;


### PR DESCRIPTION
Individual breeds were never found.  Due to a mismatch on the casing.  This sets the breeds to lowercase to match the user input.