### PR TITLE
Fix pluralization in success message for /unregister command

### DIFF
--- a/src/app/commands/unregister.command.ts
+++ b/src/app/commands/unregister.command.ts
@@ -92,7 +92,7 @@ export default {
 
     if (numSuccessfulClasses !== 0) {
       await interaction.followUp({
-        content: `Successfully removed from ${numSuccessfulClasses} classes`,
+        content: `Successfully removed from ${numSuccessfulClasses} ${numSuccessfulClasses === 1 ? 'class' : 'classes'}`,
       });
     }
 


### PR DESCRIPTION
Adjusts success message for /unregister to use "class" or "classes" depending on count. Previously it would always say "classes".

![image](https://github.com/user-attachments/assets/b58af95e-eccf-43b0-9511-0d35e85d0cff)
